### PR TITLE
Cabal fixes

### DIFF
--- a/hslice.cabal
+++ b/hslice.cabal
@@ -14,15 +14,15 @@ Category:            Graphics
 
 Library
     Build-depends:
-                  base,
-                  bytestring,
-                  data-ordlist,
-                  deepseq,
-                  double-conversion,
-                  implicit,
-                  mtl,
-                  parallel,
-                  utf8-string
+                    base
+                  , bytestring
+                  , data-ordlist
+                  , deepseq
+                  , double-conversion
+                  , implicit
+                  , mtl
+                  , parallel
+                  , utf8-string
     Ghc-options:
                 -optc-O3
                 -- see GHC manual 8.2.1 section 6.5.1.
@@ -54,19 +54,19 @@ Executable extcuraengine
     Main-is: extcuraengine.hs
     Hs-source-dirs: programs
     Build-depends:
-                  base,
-                  bytestring,
-                  data-ordlist,
-                  deepseq,
-                  double-conversion,
-                  formatting,
-                  hslice,
-                  implicit,
-                  mtl,
-                  optparse-applicative,
-                  parallel,
-                  text,
-                  utf8-string
+                    base
+                  , bytestring
+                  , data-ordlist
+                  , deepseq
+                  , double-conversion
+                  , formatting
+                  , hslice
+                  , implicit
+                  , mtl
+                  , optparse-applicative
+                  , parallel
+                  , text
+                  , utf8-string
     Ghc-options:
                 -threaded
                 -rtsopts

--- a/hslice.cabal
+++ b/hslice.cabal
@@ -56,16 +56,11 @@ Executable extcuraengine
     Build-depends:
                     base
                   , bytestring
-                  , data-ordlist
-                  , deepseq
-                  , double-conversion
-                  , formatting
                   , hslice
                   , implicit
                   , mtl
                   , optparse-applicative
                   , parallel
-                  , text
                   , utf8-string
     Ghc-options:
                 -threaded

--- a/hslice.cabal
+++ b/hslice.cabal
@@ -30,7 +30,6 @@ Library
                 -- for debugging.
                 -Wall
                 -Wextra
-                -Weverything
 		-- for profiling.
     Exposed-Modules:
                     Graphics.Slicer
@@ -77,7 +76,6 @@ Executable extcuraengine
                 -- for debugging.
                 -Wall
                 -Wextra
-                -Weverything
 		-- for profiling.
 --                -prof
 --                -fprof-auto

--- a/hslice.cabal
+++ b/hslice.cabal
@@ -31,7 +31,6 @@ Library
                 -Wall
                 -Wextra
                 -Wunused-packages
-		-- for profiling.
     Exposed-Modules:
                     Graphics.Slicer
                     Graphics.Slicer.Machine.StateM
@@ -50,7 +49,7 @@ Library
                   Graphics.Slicer.Mechanics.Definitions
                   Graphics.Slicer.Concepts.Definitions
                   Graphics.Slicer.Definitions
-                  
+
 Executable extcuraengine
     Main-is: extcuraengine.hs
     Hs-source-dirs: programs
@@ -78,7 +77,7 @@ Executable extcuraengine
                 -Wall
                 -Wextra
                 -Wunused-packages
-		-- for profiling.
+                -- for profiling.
 --                -prof
 --                -fprof-auto
 

--- a/hslice.cabal
+++ b/hslice.cabal
@@ -30,6 +30,7 @@ Library
                 -- for debugging.
                 -Wall
                 -Wextra
+                -Wunused-packages
 		-- for profiling.
     Exposed-Modules:
                     Graphics.Slicer
@@ -76,6 +77,7 @@ Executable extcuraengine
                 -- for debugging.
                 -Wall
                 -Wextra
+                -Wunused-packages
 		-- for profiling.
 --                -prof
 --                -fprof-auto


### PR DESCRIPTION
Reformatted a bit, dropped `-Weverything` and added `-Wunused-packages` instead which is quite nice GHC8.10 feature. `-Weverything` is a bit too verbose and the clutter hides few "real" warnings.